### PR TITLE
switch mean-of-rho to full-vector Fisher z-transform for significance and CI calculations

### DIFF
--- a/src/CCM.cpp
+++ b/src/CCM.cpp
@@ -294,21 +294,45 @@ std::vector<std::vector<double>> CCM(
     grouped_results[result.first].push_back(result.second);
   }
 
+  // // Previous implementation calculated significance and confidence intervals using the mean of rho vector only.
+  // // This approach is now deprecated and kept here for comparison purposes.
+  // std::vector<std::vector<double>> final_results;
+  // for (const auto& group : grouped_results) {
+  //   double mean_value = CppMean(group.second, true);
+  //   final_results.push_back({static_cast<double>(group.first), mean_value});
+  // }
+  //
+  // // Calculate significance and confidence interval for each result
+  // for (size_t i = 0; i < final_results.size(); ++i) {
+  //   double rho = final_results[i][1];
+  //   double significance = CppCorSignificance(rho, n);
+  //   std::vector<double> confidence_interval = CppCorConfidence(rho, n);
+  //
+  //   final_results[i].push_back(significance);
+  //   final_results[i].push_back(confidence_interval[0]);
+  //   final_results[i].push_back(confidence_interval[1]);
+  // }
+
+  // Refactor correlation analysis to compute significance and confidence intervals directly from grouped correlation vectors
   std::vector<std::vector<double>> final_results;
   for (const auto& group : grouped_results) {
+    // Calculate the mean correlation coefficient from the group
     double mean_value = CppMean(group.second, true);
-    final_results.push_back({static_cast<double>(group.first), mean_value});
-  }
 
-  // Calculate significance and confidence interval for each result
-  for (size_t i = 0; i < final_results.size(); ++i) {
-    double rho = final_results[i][1];
-    double significance = CppCorSignificance(rho, n);
-    std::vector<double> confidence_interval = CppCorConfidence(rho, n);
+    // Compute significance (p-value) using the vector of correlations directly
+    double significance = CppMeanCorSignificance(group.second, n);
 
-    final_results[i].push_back(significance);
-    final_results[i].push_back(confidence_interval[0]);
-    final_results[i].push_back(confidence_interval[1]);
+    // Compute confidence interval using the vector of correlations directly
+    std::vector<double> confidence_interval = CppMeanCorConfidence(group.second, n);
+
+    // Store results: group ID, mean correlation, p-value, lower CI, upper CI
+    final_results.push_back({
+      static_cast<double>(group.first),
+      mean_value,
+      significance,
+      confidence_interval[0],
+                         confidence_interval[1]
+    });
   }
 
   return final_results;

--- a/src/CCM.cpp
+++ b/src/CCM.cpp
@@ -331,7 +331,7 @@ std::vector<std::vector<double>> CCM(
       mean_value,
       significance,
       confidence_interval[0],
-                         confidence_interval[1]
+      confidence_interval[1]
     });
   }
 

--- a/src/PCM.cpp
+++ b/src/PCM.cpp
@@ -501,44 +501,81 @@ std::vector<std::vector<double>> PCM(
     grouped_results[result.first].emplace_back(result.second, result.third);
   }
 
-  std::vector<std::vector<double>> final_results;
+  // // Previous implementation calculated significance and confidence intervals using the mean of rho vector only.
+  // // This approach is now deprecated and kept here for comparison purposes.
+  // std::vector<std::vector<double>> final_results;
+  // // Compute the mean of second and third values for each group
+  // for (const auto& group : grouped_results) {
+  //   std::vector<double> second_values, third_values;
+  //
+  //   for (const auto& val : group.second) {
+  //     second_values.push_back(val.first);
+  //     third_values.push_back(val.second);
+  //   }
+  //
+  //   double mean_second = CppMean(second_values, true);
+  //   double mean_third = CppMean(third_values, true);
+  //
+  //   final_results.push_back({static_cast<double>(group.first), mean_second, mean_third});
+  // }
+  //
+  // // Compute significance and confidence intervals for each result
+  // for (size_t i = 0; i < final_results.size(); ++i) {
+  //   double rho_second = final_results[i][1];
+  //   double rho_third = final_results[i][2];
+  //
+  //   // Compute significance and confidence interval for second value
+  //   double significance_second = CppCorSignificance(rho_second, n);
+  //   std::vector<double> confidence_interval_second = CppCorConfidence(rho_second, n);
+  //
+  //   // Compute significance and confidence interval for third value
+  //   double significance_third = CppCorSignificance(rho_third, n, n_confounds);
+  //   std::vector<double> confidence_interval_third = CppCorConfidence(rho_third, n, n_confounds);
+  //
+  //   // Append computed statistical values to the result
+  //   final_results[i].push_back(significance_second);
+  //   final_results[i].push_back(confidence_interval_second[0]);
+  //   final_results[i].push_back(confidence_interval_second[1]);
+  //
+  //   final_results[i].push_back(significance_third);
+  //   final_results[i].push_back(confidence_interval_third[0]);
+  //   final_results[i].push_back(confidence_interval_third[1]);
+  // }
 
-  // Compute the mean of second and third values for each group
+  // For each group, compute the mean of second and third values and calculate significance and confidence intervals using the original vectors
+  std::vector<std::vector<double>> final_results;
   for (const auto& group : grouped_results) {
     std::vector<double> second_values, third_values;
 
+    // Collect all second and third values from current group
     for (const auto& val : group.second) {
       second_values.push_back(val.first);
       third_values.push_back(val.second);
     }
 
+    // Compute mean values for reporting
     double mean_second = CppMean(second_values, true);
     double mean_third = CppMean(third_values, true);
 
-    final_results.push_back({static_cast<double>(group.first), mean_second, mean_third});
-  }
+    // Compute significance and confidence intervals using the full vector of values (not just mean)
+    double significance_second = CppMeanCorSignificance(second_values, n);
+    std::vector<double> confidence_interval_second = CppMeanCorConfidence(second_values, n);
 
-  // Compute significance and confidence intervals for each result
-  for (size_t i = 0; i < final_results.size(); ++i) {
-    double rho_second = final_results[i][1];
-    double rho_third = final_results[i][2];
+    double significance_third = CppMeanCorSignificance(third_values, n, n_confounds);
+    std::vector<double> confidence_interval_third = CppMeanCorConfidence(third_values, n, n_confounds);
 
-    // Compute significance and confidence interval for second value
-    double significance_second = CppCorSignificance(rho_second, n);
-    std::vector<double> confidence_interval_second = CppCorConfidence(rho_second, n);
-
-    // Compute significance and confidence interval for third value
-    double significance_third = CppCorSignificance(rho_third, n, n_confounds);
-    std::vector<double> confidence_interval_third = CppCorConfidence(rho_third, n, n_confounds);
-
-    // Append computed statistical values to the result
-    final_results[i].push_back(significance_second);
-    final_results[i].push_back(confidence_interval_second[0]);
-    final_results[i].push_back(confidence_interval_second[1]);
-
-    final_results[i].push_back(significance_third);
-    final_results[i].push_back(confidence_interval_third[0]);
-    final_results[i].push_back(confidence_interval_third[1]);
+    // Store group ID, mean values, and corresponding statistical results
+    final_results.push_back({
+      static_cast<double>(group.first),
+      mean_second,
+      mean_third,
+      significance_second,
+      confidence_interval_second[0],
+      confidence_interval_second[1],
+      significance_third,
+      confidence_interval_third[0],
+      confidence_interval_third[1]
+    });
   }
 
   return final_results;


### PR DESCRIPTION
This PR updates the method for computing the statistical significance of the mean correlation coefficient. Previously, the implementation computed significance by directly using the average of the correlation coefficients (mean rho), which ignores the variability within the set of correlations and can lead to biased results.

The new implementation takes the entire vector of rho values as input and applies Fisher's z-transformation before calculating the mean and its significance. This approach properly accounts for the distribution of the correlation values, providing a more statistically sound and reliable significance test.

Additionally, confidence interval calculations were updated accordingly to reflect this change.

This improvement is particularly important when dealing with correlation values derived from sliding windows (varying libraries), where variability and distribution of rho values carry important information. The change enhances the robustness and accuracy of statistical inference for causation analyses.