### PR TITLE
improve transient trimming robustness in logistic map

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # tEDM 1.1
 
+### enhancements
+
+* Safeguard transient removal logic in logistic map to prevent index errors (#96).
+
 # tEDM 1.0
 
-* First stable release.
+### new
+
+* First stable release (#93).

--- a/R/logostic_map.R
+++ b/R/logostic_map.R
@@ -30,7 +30,7 @@ logistic_map = \(x, y = NULL, z = NULL, step = 15, alpha_x = 3.6, alpha_y = 3.72
   if (is.null(y)) yl = 0;
   if (is.null(z)) zl = 0;
   res = lapply(RcppLogisticMap(xl,yl,zl,step,alpha_x,alpha_y,alpha_z,beta_xy,beta_xz,beta_yx,beta_yz,beta_zx,beta_zy,threshold),
-               \(.x) .x[-transient])
+               \(.x) .x[-unique(abs(transient))])
   if (is.null(y)) res$y = NULL
   if (is.null(z)) res$z = NULL
   return(as.data.frame(res))

--- a/R/logostic_map.R
+++ b/R/logostic_map.R
@@ -25,10 +25,10 @@
 logistic_map = \(x, y = NULL, z = NULL, step = 15, alpha_x = 3.6, alpha_y = 3.72, alpha_z = 3.68,
                  beta_xy = 0.05, beta_xz = 0.05, beta_yx = 0.2, beta_yz = 0.2, beta_zx = 0.35, beta_zy = 0.35,
                  threshold = Inf, transient = 1){
-  xl = x; yl = y; zl = z;
-  if (is.null(x)) xl = 0;
-  if (is.null(y)) yl = 0;
-  if (is.null(z)) zl = 0;
+  xl = x; yl = y; zl = z
+  if (is.null(x)) xl = 0
+  if (is.null(y)) yl = 0
+  if (is.null(z)) zl = 0
   res = lapply(RcppLogisticMap(xl,yl,zl,step,alpha_x,alpha_y,alpha_z,beta_xy,beta_xz,beta_yx,beta_yz,beta_zx,beta_zy,threshold),
                \(.x) .x[-unique(abs(transient))])
   if (is.null(y)) res$y = NULL


### PR DESCRIPTION
Replaces `.x[-transient]` with a more robust expression `.x[-unique(abs(transient))]` to handle edge cases where duplicate or negative indices may cause unexpected behavior in transient trimming.
