### PR TITLE
refine lib and pred index filtering logic for cross mapping

### DIFF
--- a/src/EDMExp.cpp
+++ b/src/EDMExp.cpp
@@ -131,8 +131,7 @@ Rcpp::NumericVector RcppSimplexForecast(
       Rcpp::stop("pred contains out-of-bounds index at position %d (value: %d)", i + 1, pred[i]);
     }
     if (!std::isnan(source_std[pred[i] - 1]) &&
-        !std::isnan(target_std[pred[i] - 1]) &&
-        (pred[i] > max_lag)) {
+        !std::isnan(target_std[pred[i] - 1])) {
       pred_indices.push_back(pred[i] - 1); // Convert to 0-based index
     }
   }
@@ -190,8 +189,7 @@ Rcpp::NumericVector RcppSMapForecast(
       Rcpp::stop("pred contains out-of-bounds index at position %d (value: %d)", i + 1, pred[i]);
     }
     if (!std::isnan(source_std[pred[i] - 1]) &&
-        !std::isnan(target_std[pred[i] - 1]) &&
-        (pred[i] > max_lag)) {
+        !std::isnan(target_std[pred[i] - 1])) {
       pred_indices.push_back(pred[i] - 1); // Convert to 0-based index
     }
   }
@@ -253,8 +251,7 @@ Rcpp::NumericVector RcppIntersectionCardinality(
       Rcpp::stop("pred contains out-of-bounds index at position %d (value: %d)", i + 1, pred[i]);
     }
     if (!std::isnan(source_std[pred[i] - 1]) &&
-        !std::isnan(target_std[pred[i] - 1]) &&
-        (pred[i] > max_lag)){
+        !std::isnan(target_std[pred[i] - 1])){
         pred_indices.push_back(static_cast<size_t>(pred[i] - 1)); // Convert to 0-based index
     }
   }
@@ -315,7 +312,7 @@ Rcpp::NumericVector RcppMVE4TS(const Rcpp::NumericMatrix& x,
     if (pred[i] < 1 || pred[i] > target_len) {
       Rcpp::stop("pred contains out-of-bounds index at position %d (value: %d)", i + 1, pred[i]);
     }
-    if (!std::isnan(target[pred[i] - 1]) && (pred[i] > max_lag)) {
+    if (!std::isnan(target[pred[i] - 1])) {
       pred_indices.push_back(pred[i] - 1); // Convert to 0-based index
     }
   }
@@ -436,7 +433,7 @@ Rcpp::NumericVector RcppFNN4TS(
     if (pred[i] < 1 || pred[i] > validSampleNum) {
       Rcpp::stop("pred contains out-of-bounds index at position %d (value: %d)", i + 1, pred[i]);
     }
-    if (!std::isnan(vec_std[pred[i] - 1]) && (pred[i] > max_lag)) {
+    if (!std::isnan(vec_std[pred[i] - 1])) {
       pred_std.push_back(pred[i] - 1);
     }
   }
@@ -498,8 +495,7 @@ Rcpp::NumericMatrix RcppSimplex4TS(const Rcpp::NumericVector& source,
       Rcpp::stop("pred contains out-of-bounds index at position %d (value: %d)", i + 1, pred[i]);
     }
     if (!std::isnan(source_std[pred[i] - 1]) &&
-        !std::isnan(target_std[pred[i] - 1]) &&
-        (pred[i] > max_lag)) {
+        !std::isnan(target_std[pred[i] - 1])) {
       pred_indices.push_back(pred[i] - 1); // Convert to 0-based index
     }
   }
@@ -572,8 +568,7 @@ Rcpp::NumericMatrix RcppSMap4TS(const Rcpp::NumericVector& source,
       Rcpp::stop("pred contains out-of-bounds index at position %d (value: %d)", i + 1, pred[i]);
     }
     if (!std::isnan(source_std[pred[i] - 1]) &&
-        !std::isnan(target_std[pred[i] - 1]) &&
-        (pred[i] > max_lag)) {
+        !std::isnan(target_std[pred[i] - 1])) {
       pred_indices.push_back(pred[i] - 1); // Convert to 0-based index
     }
   }
@@ -749,8 +744,7 @@ Rcpp::NumericMatrix RcppIC4TS(const Rcpp::NumericVector& source,
       Rcpp::stop("pred contains out-of-bounds index at position %d (value: %d)", i + 1, pred[i]);
     }
     if (!std::isnan(source_std[pred[i] - 1]) &&
-        !std::isnan(target_std[pred[i] - 1]) &&
-        (pred[i] > max_lag)) {
+        !std::isnan(target_std[pred[i] - 1])) {
       pred_indices.push_back(static_cast<size_t>(pred[i] - 1)); // Convert to 0-based index
     }
   }
@@ -837,8 +831,7 @@ Rcpp::NumericMatrix RcppCCM(const Rcpp::NumericVector& x,
       Rcpp::stop("pred contains out-of-bounds index at position %d (value: %d)", i + 1, pred[i]);
     }
     if (!std::isnan(x_std[pred[i] - 1]) &&
-        !std::isnan(y_std[pred[i] - 1]) &&
-        (pred[i] > max_lag)) {
+        !std::isnan(y_std[pred[i] - 1])) {
       pred_std.push_back(pred[i] - 1);
     }
   }
@@ -940,8 +933,7 @@ Rcpp::NumericMatrix RcppPCM(const Rcpp::NumericVector& x,
       Rcpp::stop("pred contains out-of-bounds index at position %d (value: %d)", i + 1, pred[i]);
     }
     if (!std::isnan(x_std[pred[i] - 1]) &&
-        !std::isnan(y_std[pred[i] - 1]) &&
-        (pred[i] > max_lag)) {
+        !std::isnan(y_std[pred[i] - 1])) {
       pred_std.push_back(pred[i] - 1);
     }
   }
@@ -1033,8 +1025,7 @@ Rcpp::List RcppCMC(
       Rcpp::stop("pred contains out-of-bounds index at position %d (value: %d)", i + 1, pred[i]);
     }
     if (!std::isnan(x_std[pred[i] - 1]) &&
-        !std::isnan(y_std[pred[i] - 1]) &&
-        (pred[i] > max_lag)) {
+        !std::isnan(y_std[pred[i] - 1])) {
       pred_std.push_back(static_cast<size_t>(pred[i] - 1));
     }
   }

--- a/src/PCM.cpp
+++ b/src/PCM.cpp
@@ -50,27 +50,17 @@ std::vector<double> PartialSimplex4TS(
     // Cumulative control embedding path
     std::vector<double> temp_pred;
     std::vector<std::vector<double>> temp_embedding;
-    std::vector<int> temp_lib = lib_indices;  // initialize
 
     for (int i = 0; i < n_controls; ++i) {
       if (i == 0){
         temp_pred = SimplexProjectionPrediction(vectors, controls[i], lib_indices, pred_indices, num_neighbors[0]);
       } else {
-        temp_pred = SimplexProjectionPrediction(temp_embedding, controls[i], temp_lib, pred_indices, num_neighbors[i]);
+        temp_pred = SimplexProjectionPrediction(temp_embedding, controls[i], lib_indices, pred_indices, num_neighbors[i]);
       }
-
-      // Reconstruct temp_lib from full lib_indices each time
-      temp_lib.clear();
-      for (int idx : lib_indices) {
-        if (!std::isnan(temp_pred[idx])) {
-          temp_lib.push_back(idx);
-        }
-      }
-
       temp_embedding = Embed(temp_pred,conEs[i],taus[i]);
     }
 
-    std::vector<double> con_pred = SimplexProjectionPrediction(temp_embedding, target, temp_lib, pred_indices, num_neighbors[n_controls]);
+    std::vector<double> con_pred = SimplexProjectionPrediction(temp_embedding, target, lib_indices, pred_indices, num_neighbors[n_controls]);
     std::vector<double> target_pred = SimplexProjectionPrediction(vectors, target, lib_indices, pred_indices, num_neighbors[0]);
 
     if (checkOneDimVectorNotNanNum(target_pred) >= 3){
@@ -85,17 +75,8 @@ std::vector<double> PartialSimplex4TS(
 
     for (int i = 0; i < n_controls; ++i) {
       temp_pred = SimplexProjectionPrediction(vectors, controls[i], lib_indices, pred_indices, num_neighbors[0]);
-
-      // In-place filter lib_indices to get valid temp_lib
-      std::vector<int> temp_lib;
-      for (int idx : lib_indices) {
-        if (!std::isnan(temp_pred[idx])) {
-          temp_lib.push_back(idx);
-        }
-      }
-
       temp_embedding = Embed(temp_pred,conEs[i],taus[i]);
-      temp_pred = SimplexProjectionPrediction(temp_embedding, target, temp_lib, pred_indices, num_neighbors[i+1]);
+      temp_pred = SimplexProjectionPrediction(temp_embedding, target, lib_indices, pred_indices, num_neighbors[i+1]);
       con_pred[i] = temp_pred;
     }
     std::vector<double> target_pred = SimplexProjectionPrediction(vectors, target, lib_indices, pred_indices, num_neighbors[0]);
@@ -150,27 +131,17 @@ std::vector<double> PartialSMap4TS(
     // Cumulative control embedding path
     std::vector<double> temp_pred;
     std::vector<std::vector<double>> temp_embedding;
-    std::vector<int> temp_lib = lib_indices;  // initialize
 
     for (int i = 0; i < n_controls; ++i) {
       if (i == 0){
         temp_pred = SMapPrediction(vectors, controls[i], lib_indices, pred_indices, num_neighbors[0], theta);
       } else {
-        temp_pred = SMapPrediction(temp_embedding, controls[i], temp_lib, pred_indices, num_neighbors[i], theta);
+        temp_pred = SMapPrediction(temp_embedding, controls[i], lib_indices, pred_indices, num_neighbors[i], theta);
       }
-
-      // Reconstruct temp_lib from full lib_indices each time
-      temp_lib.clear();
-      for (int idx : lib_indices) {
-        if (!std::isnan(temp_pred[idx])) {
-          temp_lib.push_back(idx);
-        }
-      }
-
       temp_embedding = Embed(temp_pred,conEs[i],taus[i]);
     }
 
-    std::vector<double> con_pred = SMapPrediction(temp_embedding, target, temp_lib, pred_indices, num_neighbors[n_controls], theta);
+    std::vector<double> con_pred = SMapPrediction(temp_embedding, target, lib_indices, pred_indices, num_neighbors[n_controls], theta);
     std::vector<double> target_pred = SMapPrediction(vectors, target, lib_indices, pred_indices, num_neighbors[0], theta);
 
     if (checkOneDimVectorNotNanNum(target_pred) >= 3){
@@ -185,17 +156,8 @@ std::vector<double> PartialSMap4TS(
 
     for (int i = 0; i < n_controls; ++i) {
       temp_pred = SMapPrediction(vectors, controls[i], lib_indices, pred_indices, num_neighbors[0], theta);
-
-      // In-place filter lib_indices to get valid temp_lib
-      std::vector<int> temp_lib;
-      for (int idx : lib_indices) {
-        if (!std::isnan(temp_pred[idx])) {
-          temp_lib.push_back(idx);
-        }
-      }
-
       temp_embedding = Embed(temp_pred,conEs[i],taus[i]);
-      temp_pred = SMapPrediction(temp_embedding, target, temp_lib, pred_indices, num_neighbors[i+1], theta);
+      temp_pred = SMapPrediction(temp_embedding, target, lib_indices, pred_indices, num_neighbors[i+1], theta);
       con_pred[i] = temp_pred;
     }
     std::vector<double> target_pred = SMapPrediction(vectors, target, lib_indices, pred_indices, num_neighbors[0], theta);


### PR DESCRIPTION
- Prevents spurious NaNs in cross mapping results due to overly strict lag thresholds, especially when `tau >= 1`.
- Improves prediction stability and embedding consistency.
