### PR TITLE
enable different distance metrics

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,8 +17,8 @@ RcppSMapForecast <- function(source, target, E, tau, lib, pred, num_neighbors, t
     .Call(`_tEDM_RcppSMapForecast`, source, target, E, tau, lib, pred, num_neighbors, theta, dist_metric, dist_average)
 }
 
-RcppIntersectionCardinality <- function(source, target, E, tau, lib, pred, num_neighbors = 4L, n_excluded = 0L, threads = 8L, parallel_level = 0L) {
-    .Call(`_tEDM_RcppIntersectionCardinality`, source, target, E, tau, lib, pred, num_neighbors, n_excluded, threads, parallel_level)
+RcppIntersectionCardinality <- function(source, target, E, tau, lib, pred, num_neighbors = 4L, n_excluded = 0L, dist_metric = 2L, threads = 8L, parallel_level = 0L) {
+    .Call(`_tEDM_RcppIntersectionCardinality`, source, target, E, tau, lib, pred, num_neighbors, n_excluded, dist_metric, threads, parallel_level)
 }
 
 RcppMVE4TS <- function(x, y, lib, pred, E, tau, b, top, nvar, threads) {
@@ -41,8 +41,8 @@ RcppMultiSimplex4TS <- function(source, target, lib, pred, E, b, tau = 1L, dist_
     .Call(`_tEDM_RcppMultiSimplex4TS`, source, target, lib, pred, E, b, tau, dist_metric, dist_average, threads)
 }
 
-RcppIC4TS <- function(source, target, lib, pred, E, b, tau = 1L, exclude = 0L, threads = 8L, parallel_level = 0L) {
-    .Call(`_tEDM_RcppIC4TS`, source, target, lib, pred, E, b, tau, exclude, threads, parallel_level)
+RcppIC4TS <- function(source, target, lib, pred, E, b, tau = 1L, exclude = 0L, dist_metric = 2L, threads = 8L, parallel_level = 0L) {
+    .Call(`_tEDM_RcppIC4TS`, source, target, lib, pred, E, b, tau, exclude, dist_metric, threads, parallel_level)
 }
 
 RcppCCM <- function(x, y, libsizes, lib, pred, E = 3L, tau = 0L, b = 4L, simplex = TRUE, theta = 0, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
@@ -53,8 +53,8 @@ RcppPCM <- function(x, y, z, libsizes, lib, pred, E, tau, b, simplex = TRUE, the
     .Call(`_tEDM_RcppPCM`, x, y, z, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, cumulate, progressbar)
 }
 
-RcppCMC <- function(x, y, libsizes, lib, pred, E, tau, b, r = 0L, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
-    .Call(`_tEDM_RcppCMC`, x, y, libsizes, lib, pred, E, tau, b, r, threads, parallel_level, progressbar)
+RcppCMC <- function(x, y, libsizes, lib, pred, E, tau, b = 4L, r = 0L, dist_metric = 2L, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
+    .Call(`_tEDM_RcppCMC`, x, y, libsizes, lib, pred, E, tau, b, r, dist_metric, threads, parallel_level, progressbar)
 }
 
 RcppMultispatialCCM <- function(x, y, libsizes, E = 3L, tau = 0L, b = 4L, boot = 299L, seed = 42L, threads = 8L, parallel_level = 0L, progressbar = FALSE) {

--- a/R/cmc.R
+++ b/R/cmc.R
@@ -1,5 +1,5 @@
-.cmc_ts_method = \(data, cause, effect, libsizes = NULL, E = 3, tau = 0, k = pmin(E^2), lib = NULL, pred = NULL,
-                   threads = length(pred), parallel.level = "low", bidirectional = TRUE, progressbar = TRUE){
+.cmc_ts_method = \(data, cause, effect, libsizes = NULL, E = 3, tau = 1, k = pmin(E^2), lib = NULL, pred = NULL,
+                   dist.metric = "L2", threads = length(pred), parallel.level = "low", bidirectional = TRUE, progressbar = TRUE){
   varname = .check_character(cause, effect)
   E = .check_inputelementnum(E,2)
   tau = .check_inputelementnum(tau,2)
@@ -16,9 +16,9 @@
 
   x_xmap_y = NULL
   if (bidirectional){
-    x_xmap_y = RcppCMC(cause,effect,libsizes,lib,pred,E,tau,k[1],0,threads,pl,progressbar)
+    x_xmap_y = RcppCMC(cause,effect,libsizes,lib,pred,E,tau,k[1],0,.check_distmetric(dist.metric),threads,pl,progressbar)
   }
-  y_xmap_x = RcppCMC(effect,cause,libsizes,lib,pred,rev(E),rev(tau),k[2],0,threads,pl,progressbar)
+  y_xmap_x = RcppCMC(effect,cause,libsizes,lib,pred,rev(E),rev(tau),k[2],0,.check_distmetric(dist.metric),threads,pl,progressbar)
 
   return(.bind_intersectdf(varname,x_xmap_y,y_xmap_x,bidirectional))
 }
@@ -32,6 +32,7 @@
 #' @param E (optional) embedding dimensions.
 #' @param tau (optional) step of time lags.
 #' @param k (optional) number of nearest neighbors.
+#' @param dist.metric (optional) distance metric (`L1`: Manhattan, `L2`: Euclidean).
 #' @param lib (optional) libraries indices.
 #' @param pred (optional) predictions indices.
 #' @param threads (optional) number of threads to use.

--- a/R/ic.R
+++ b/R/ic.R
@@ -1,5 +1,5 @@
-.ic_ts_method = \(data, column, target, lib = NULL, pred = NULL, E = 2:10, tau = 0,
-                  k = E+2, threads = length(pred), parallel.level = "low"){
+.ic_ts_method = \(data, column, target, lib = NULL, pred = NULL, E = 2:10, tau = 1, k = E+2,
+                  dist.metric = "L2", threads = length(pred), parallel.level = "low"){
   vx = .uni_ts(data,column)
   vy = .uni_ts(data,target)
   pl = .check_parallellevel(parallel.level)
@@ -8,7 +8,7 @@
   if (is.null(pred)) pred = lib
   if (threads == 0) threads = length(pred)
 
-  res = RcppIC4TS(vx,vy,lib,pred,E,k,tau,0,threads,pl)
+  res = RcppIC4TS(vx,vy,lib,pred,E,k,tau,0,.check_distmetric(dist.metric),threads,pl)
   return(.bind_xmapself(res,target,"ic",tau))
 }
 

--- a/man/cmc.Rd
+++ b/man/cmc.Rd
@@ -11,10 +11,11 @@
   effect,
   libsizes = NULL,
   E = 3,
-  tau = 0,
+  tau = 1,
   k = pmin(E^2),
   lib = NULL,
   pred = NULL,
+  dist.metric = "L2",
   threads = length(pred),
   parallel.level = "low",
   bidirectional = TRUE,
@@ -39,6 +40,8 @@
 \item{lib}{(optional) libraries indices.}
 
 \item{pred}{(optional) predictions indices.}
+
+\item{dist.metric}{(optional) distance metric (\code{L1}: Manhattan, \code{L2}: Euclidean).}
 
 \item{threads}{(optional) number of threads to use.}
 

--- a/man/ic.Rd
+++ b/man/ic.Rd
@@ -12,8 +12,9 @@
   lib = NULL,
   pred = NULL,
   E = 2:10,
-  tau = 0,
+  tau = 1,
   k = E + 2,
+  dist.metric = "L2",
   threads = length(pred),
   parallel.level = "low"
 )
@@ -34,6 +35,8 @@
 \item{tau}{(optional) step of time lags.}
 
 \item{k}{(optional) number of nearest neighbors used in prediction.}
+
+\item{dist.metric}{(optional) distance metric (\code{L1}: Manhattan, \code{L2}: Euclidean).}
 
 \item{threads}{(optional) number of threads to use.}
 

--- a/src/CMC.h
+++ b/src/CMC.h
@@ -28,6 +28,7 @@
  * @param pred Indices of prediction points (0-based).
  * @param num_neighbors Number of neighbors used in cross mapping.
  * @param n_excluded Number of temporally excluded neighbors (Theiler window).
+ * @param dist_metric Distance metric selector (1: Manhattan, 2: Euclidean).
  * @param threads Number of threads for parallel processing.
  * @param parallel_level Level of parallelism to control nested parallel execution.
  * @param progressbar Boolean flag to show or hide a progress bar.
@@ -44,6 +45,7 @@ CMCRes CMC(
     const std::vector<size_t>& pred,
     size_t num_neighbors = 4,
     size_t n_excluded = 0,
+    int dist_metric = 2,
     int threads = 8,
     int parallel_level = 0,
     bool progressbar = true);

--- a/src/EDMExp.cpp
+++ b/src/EDMExp.cpp
@@ -228,6 +228,7 @@ Rcpp::NumericVector RcppIntersectionCardinality(
     const Rcpp::IntegerVector& pred,
     const int& num_neighbors = 4,
     const int& n_excluded = 0,
+    const int& dist_metric = 2,
     const int& threads = 8,
     const int& parallel_level = 0){
   // Convert Rcpp::NumericVector to std::vector<double>
@@ -277,6 +278,7 @@ Rcpp::NumericVector RcppIntersectionCardinality(
     pred_indices,
     static_cast<size_t>(num_neighbors),
     static_cast<size_t>(n_excluded),
+    dist_metric,
     threads,
     parallel_level
   );
@@ -731,6 +733,7 @@ Rcpp::NumericMatrix RcppIC4TS(const Rcpp::NumericVector& source,
                               const Rcpp::IntegerVector& b,
                               int tau = 1,
                               int exclude = 0,
+                              int dist_metric = 2,
                               int threads = 8,
                               int parallel_level = 0) {
   // Convert Rcpp::NumericVector to std::vector<double>
@@ -788,6 +791,7 @@ Rcpp::NumericMatrix RcppIC4TS(const Rcpp::NumericVector& source,
     b_std,
     tau,
     exclude,
+    dist_metric,
     threads,
     parallel_level);
 

--- a/src/EDMExp.cpp
+++ b/src/EDMExp.cpp
@@ -1014,8 +1014,9 @@ Rcpp::List RcppCMC(
     const Rcpp::IntegerVector& pred,
     const Rcpp::IntegerVector& E,
     const Rcpp::IntegerVector& tau,
-    int b,
+    int b = 4,
     int r = 0,
+    int dist_metric = 2,
     int threads = 8,
     int parallel_level = 0,
     bool progressbar = false){
@@ -1070,7 +1071,7 @@ Rcpp::List RcppCMC(
   // Perform CMC for time series data
   CMCRes res = CMC(e1,e2,libsizes_std,lib_std,pred_std,
                    static_cast<size_t>(b),static_cast<size_t>(r),
-                   threads,parallel_level,progressbar);
+                   dist_metric,threads,parallel_level,progressbar);
 
   // Convert mean_aucs to Rcpp::DataFrame
   std::vector<double> libs, aucs;

--- a/src/IntersectionCardinality.cpp
+++ b/src/IntersectionCardinality.cpp
@@ -7,7 +7,7 @@
 #include <unordered_map>
 #include "CppStats.h"
 #include "CppDistances.h"
-#include "spEDMDataStruct.h"
+#include "tEDMDataStruct.h"
 #include <RcppThread.h>
 
 // [[Rcpp::depends(RcppThread)]]

--- a/src/IntersectionCardinality.h
+++ b/src/IntersectionCardinality.h
@@ -10,7 +10,7 @@
 #include <unordered_map>
 #include "CppStats.h"
 #include "CppDistances.h"
-#include "spEDMDataStruct.h"
+#include "tEDMDataStruct.h"
 #include <RcppThread.h>
 
 /**

--- a/src/IntersectionCardinality.h
+++ b/src/IntersectionCardinality.h
@@ -10,7 +10,7 @@
 #include <unordered_map>
 #include "CppStats.h"
 #include "CppDistances.h"
-#include "tEDMDataStruct.h"
+#include "spEDMDataStruct.h"
 #include <RcppThread.h>
 
 /**
@@ -68,6 +68,7 @@ std::vector<IntersectionRes> IntersectionCardinalitySingle(
  * @param pred            Vector of prediction indices (shouble be 0-based in C++).
  * @param num_neighbors   Maximum number of neighbors to consider in intersection (e.g., from 1 to k).
  * @param n_excluded      Number of nearest neighbors to exclude (e.g., due to temporal proximity).
+ * @param dist_metric     Distance metric selector (1: Manhattan, 2: Euclidean).
  * @param threads         Number of threads used for parallel computation.
  * @param parallel_level  Parallel mode flag: 0 = parallel, 1 = serial.
  *
@@ -89,7 +90,8 @@ std::vector<double> IntersectionCardinality(
     const std::vector<size_t>& pred,
     size_t num_neighbors,
     size_t n_excluded,
-    int threads,
+    int dist_metric = 2,
+    int threads = 8,
     int parallel_level = 0);
 
 /**
@@ -107,6 +109,7 @@ std::vector<double> IntersectionCardinality(
  *   pred           - Prediction index vector (shouble be 0-based in C++).
  *   num_neighbors  - Number of neighbors used for cross mapping (after exclusion).
  *   n_excluded     - Number of nearest neighbors to exclude (e.g. temporal).
+ *   dist_metric    - Distance metric selector (1: Manhattan, 2: Euclidean).
  *   threads        - Number of threads used in parallel computation.
  *   parallel_level - Whether to use multithreaded (0) or serial (1) mode
  *
@@ -124,7 +127,8 @@ std::vector<double> IntersectionCardinalityScores(
     const std::vector<size_t>& pred,
     size_t num_neighbors,
     size_t n_excluded,
-    int threads,
+    int dist_metric = 2,
+    int threads = 8,
     int parallel_level = 0);
 
 #endif // IntersectionCardinality_H

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -86,8 +86,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppIntersectionCardinality
-Rcpp::NumericVector RcppIntersectionCardinality(const Rcpp::NumericVector& source, const Rcpp::NumericVector& target, int E, int tau, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const int& num_neighbors, const int& n_excluded, const int& threads, const int& parallel_level);
-RcppExport SEXP _tEDM_RcppIntersectionCardinality(SEXP sourceSEXP, SEXP targetSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP libSEXP, SEXP predSEXP, SEXP num_neighborsSEXP, SEXP n_excludedSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP) {
+Rcpp::NumericVector RcppIntersectionCardinality(const Rcpp::NumericVector& source, const Rcpp::NumericVector& target, int E, int tau, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const int& num_neighbors, const int& n_excluded, const int& dist_metric, const int& threads, const int& parallel_level);
+RcppExport SEXP _tEDM_RcppIntersectionCardinality(SEXP sourceSEXP, SEXP targetSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP libSEXP, SEXP predSEXP, SEXP num_neighborsSEXP, SEXP n_excludedSEXP, SEXP dist_metricSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type source(sourceSEXP);
@@ -98,9 +98,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type pred(predSEXP);
     Rcpp::traits::input_parameter< const int& >::type num_neighbors(num_neighborsSEXP);
     Rcpp::traits::input_parameter< const int& >::type n_excluded(n_excludedSEXP);
+    Rcpp::traits::input_parameter< const int& >::type dist_metric(dist_metricSEXP);
     Rcpp::traits::input_parameter< const int& >::type threads(threadsSEXP);
     Rcpp::traits::input_parameter< const int& >::type parallel_level(parallel_levelSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppIntersectionCardinality(source, target, E, tau, lib, pred, num_neighbors, n_excluded, threads, parallel_level));
+    rcpp_result_gen = Rcpp::wrap(RcppIntersectionCardinality(source, target, E, tau, lib, pred, num_neighbors, n_excluded, dist_metric, threads, parallel_level));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -200,8 +201,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppIC4TS
-Rcpp::NumericMatrix RcppIC4TS(const Rcpp::NumericVector& source, const Rcpp::NumericVector& target, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& b, int tau, int exclude, int threads, int parallel_level);
-RcppExport SEXP _tEDM_RcppIC4TS(SEXP sourceSEXP, SEXP targetSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP bSEXP, SEXP tauSEXP, SEXP excludeSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP) {
+Rcpp::NumericMatrix RcppIC4TS(const Rcpp::NumericVector& source, const Rcpp::NumericVector& target, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& b, int tau, int exclude, int dist_metric, int threads, int parallel_level);
+RcppExport SEXP _tEDM_RcppIC4TS(SEXP sourceSEXP, SEXP targetSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP bSEXP, SEXP tauSEXP, SEXP excludeSEXP, SEXP dist_metricSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type source(sourceSEXP);
@@ -212,9 +213,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type b(bSEXP);
     Rcpp::traits::input_parameter< int >::type tau(tauSEXP);
     Rcpp::traits::input_parameter< int >::type exclude(excludeSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
     Rcpp::traits::input_parameter< int >::type parallel_level(parallel_levelSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppIC4TS(source, target, lib, pred, E, b, tau, exclude, threads, parallel_level));
+    rcpp_result_gen = Rcpp::wrap(RcppIC4TS(source, target, lib, pred, E, b, tau, exclude, dist_metric, threads, parallel_level));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -265,8 +267,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppCMC
-Rcpp::List RcppCMC(const Rcpp::NumericVector& x, const Rcpp::NumericVector& y, const Rcpp::IntegerVector& libsizes, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& tau, int b, int r, int threads, int parallel_level, bool progressbar);
-RcppExport SEXP _tEDM_RcppCMC(SEXP xSEXP, SEXP ySEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP rSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP progressbarSEXP) {
+Rcpp::List RcppCMC(const Rcpp::NumericVector& x, const Rcpp::NumericVector& y, const Rcpp::IntegerVector& libsizes, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& tau, int b, int r, int dist_metric, int threads, int parallel_level, bool progressbar);
+RcppExport SEXP _tEDM_RcppCMC(SEXP xSEXP, SEXP ySEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP rSEXP, SEXP dist_metricSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP progressbarSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type x(xSEXP);
@@ -278,10 +280,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::IntegerVector& >::type tau(tauSEXP);
     Rcpp::traits::input_parameter< int >::type b(bSEXP);
     Rcpp::traits::input_parameter< int >::type r(rSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
     Rcpp::traits::input_parameter< int >::type parallel_level(parallel_levelSEXP);
     Rcpp::traits::input_parameter< bool >::type progressbar(progressbarSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppCMC(x, y, libsizes, lib, pred, E, tau, b, r, threads, parallel_level, progressbar));
+    rcpp_result_gen = Rcpp::wrap(RcppCMC(x, y, libsizes, lib, pred, E, tau, b, r, dist_metric, threads, parallel_level, progressbar));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -831,16 +834,16 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tEDM_RcppEmbed", (DL_FUNC) &_tEDM_RcppEmbed, 4},
     {"_tEDM_RcppSimplexForecast", (DL_FUNC) &_tEDM_RcppSimplexForecast, 9},
     {"_tEDM_RcppSMapForecast", (DL_FUNC) &_tEDM_RcppSMapForecast, 10},
-    {"_tEDM_RcppIntersectionCardinality", (DL_FUNC) &_tEDM_RcppIntersectionCardinality, 10},
+    {"_tEDM_RcppIntersectionCardinality", (DL_FUNC) &_tEDM_RcppIntersectionCardinality, 11},
     {"_tEDM_RcppMVE4TS", (DL_FUNC) &_tEDM_RcppMVE4TS, 10},
     {"_tEDM_RcppFNN4TS", (DL_FUNC) &_tEDM_RcppFNN4TS, 9},
     {"_tEDM_RcppSimplex4TS", (DL_FUNC) &_tEDM_RcppSimplex4TS, 10},
     {"_tEDM_RcppSMap4TS", (DL_FUNC) &_tEDM_RcppSMap4TS, 11},
     {"_tEDM_RcppMultiSimplex4TS", (DL_FUNC) &_tEDM_RcppMultiSimplex4TS, 10},
-    {"_tEDM_RcppIC4TS", (DL_FUNC) &_tEDM_RcppIC4TS, 10},
+    {"_tEDM_RcppIC4TS", (DL_FUNC) &_tEDM_RcppIC4TS, 11},
     {"_tEDM_RcppCCM", (DL_FUNC) &_tEDM_RcppCCM, 13},
     {"_tEDM_RcppPCM", (DL_FUNC) &_tEDM_RcppPCM, 15},
-    {"_tEDM_RcppCMC", (DL_FUNC) &_tEDM_RcppCMC, 12},
+    {"_tEDM_RcppCMC", (DL_FUNC) &_tEDM_RcppCMC, 13},
     {"_tEDM_RcppMultispatialCCM", (DL_FUNC) &_tEDM_RcppMultispatialCCM, 11},
     {"_tEDM_DetectMaxNumThreads", (DL_FUNC) &_tEDM_DetectMaxNumThreads, 0},
     {"_tEDM_OptEmbedDim", (DL_FUNC) &_tEDM_OptEmbedDim, 1},


### PR DESCRIPTION
`ic` and `cmc` now support `dist.metric` to choose between `L1` and `L2` distance metrics.