### PR TITLE
enable different distance metrics

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -45,20 +45,20 @@ RcppIC4TS <- function(source, target, lib, pred, E, b, tau = 1L, exclude = 0L, d
     .Call(`_tEDM_RcppIC4TS`, source, target, lib, pred, E, b, tau, exclude, dist_metric, threads, parallel_level)
 }
 
-RcppCCM <- function(x, y, libsizes, lib, pred, E = 3L, tau = 0L, b = 4L, simplex = TRUE, theta = 0, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
-    .Call(`_tEDM_RcppCCM`, x, y, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, progressbar)
+RcppCCM <- function(x, y, libsizes, lib, pred, E = 3L, tau = 0L, b = 4L, simplex = TRUE, theta = 0, threads = 8L, parallel_level = 0L, dist_metric = 2L, dist_average = TRUE, progressbar = FALSE) {
+    .Call(`_tEDM_RcppCCM`, x, y, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, dist_metric, dist_average, progressbar)
 }
 
-RcppPCM <- function(x, y, z, libsizes, lib, pred, E, tau, b, simplex = TRUE, theta = 0, threads = 8L, parallel_level = 0L, cumulate = FALSE, progressbar = FALSE) {
-    .Call(`_tEDM_RcppPCM`, x, y, z, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, cumulate, progressbar)
+RcppPCM <- function(x, y, z, libsizes, lib, pred, E, tau, b, simplex = TRUE, theta = 0, threads = 8L, parallel_level = 0L, cumulate = FALSE, dist_metric = 2L, dist_average = TRUE, progressbar = FALSE) {
+    .Call(`_tEDM_RcppPCM`, x, y, z, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, cumulate, dist_metric, dist_average, progressbar)
 }
 
 RcppCMC <- function(x, y, libsizes, lib, pred, E, tau, b = 4L, r = 0L, dist_metric = 2L, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
     .Call(`_tEDM_RcppCMC`, x, y, libsizes, lib, pred, E, tau, b, r, dist_metric, threads, parallel_level, progressbar)
 }
 
-RcppMultispatialCCM <- function(x, y, libsizes, E = 3L, tau = 0L, b = 4L, boot = 299L, seed = 42L, threads = 8L, parallel_level = 0L, progressbar = FALSE) {
-    .Call(`_tEDM_RcppMultispatialCCM`, x, y, libsizes, E, tau, b, boot, seed, threads, parallel_level, progressbar)
+RcppMultispatialCCM <- function(x, y, libsizes, E = 3L, tau = 0L, b = 4L, boot = 299L, seed = 42L, threads = 8L, parallel_level = 0L, dist_metric = 2L, dist_average = TRUE, progressbar = FALSE) {
+    .Call(`_tEDM_RcppMultispatialCCM`, x, y, libsizes, E, tau, b, boot, seed, threads, parallel_level, dist_metric, dist_average, progressbar)
 }
 
 DetectMaxNumThreads <- function() {

--- a/R/ccm.R
+++ b/R/ccm.R
@@ -1,5 +1,5 @@
-.ccm_ts_method = \(data, cause, effect, libsizes = NULL, E = 3, tau = 0, k = E+1, theta = 1, algorithm = "simplex", lib = NULL,
-                   pred = NULL, threads = length(pred), parallel.level = "low", bidirectional = TRUE, progressbar = TRUE){
+.ccm_ts_method = \(data, cause, effect, libsizes = NULL, E = 3, tau = 0, k = E+1, theta = 1, algorithm = "simplex", lib = NULL, pred = NULL, 
+                   dist.metric = "L2",dist.average = TRUE,threads = length(pred),parallel.level = "low",bidirectional = TRUE,progressbar = TRUE){
   varname = .check_character(cause,effect)
   E = .check_inputelementnum(E,2)
   tau = .check_inputelementnum(tau,2)
@@ -17,9 +17,9 @@
   simplex = ifelse(algorithm == "simplex", TRUE, FALSE)
   x_xmap_y = NULL
   if (bidirectional){
-    x_xmap_y = RcppCCM(cause,effect,libsizes,lib,pred,E[1],tau[1],k[1],simplex,theta,threads,pl,progressbar)
+    x_xmap_y = RcppCCM(cause,effect,libsizes,lib,pred,E[1],tau[1],k[1],simplex,theta,threads,pl,.check_distmetric(dist.metric),dist.average,progressbar)
   }
-  y_xmap_x = RcppCCM(effect,cause,libsizes,lib,pred,E[2],tau[2],k[2],simplex,theta,threads,pl,progressbar)
+  y_xmap_x = RcppCCM(effect,cause,libsizes,lib,pred,E[2],tau[2],k[2],simplex,theta,threads,pl,.check_distmetric(dist.metric),dist.average,progressbar)
 
   return(.bind_xmapdf(varname,x_xmap_y,y_xmap_x,bidirectional))
 }
@@ -29,6 +29,7 @@
 #' @inheritParams cmc
 #' @param theta (optional) weighting parameter for distances, useful when `algorithm` is `smap`.
 #' @param algorithm (optional) prediction algorithm.
+#' @param dist.average (optional) whether to average distance.
 #'
 #' @return A list
 #' \describe{

--- a/R/multispatialccm.R
+++ b/R/multispatialccm.R
@@ -1,5 +1,5 @@
-.multispatialccm_ts_method = \(data, cause, effect, libsizes, E = 3, tau = 0, k = E+1, boot = 99, seed = 42,
-                               threads = length(libsizes), parallel.level = "low", bidirectional = TRUE, progressbar = TRUE){
+.multispatialccm_ts_method = \(data, cause, effect, libsizes, E = 3, tau = 0, k = E+1, boot = 99, seed = 42, dist.metric = "L2",
+                               dist.average = TRUE,threads = length(libsizes),parallel.level = "low",bidirectional = TRUE,progressbar = TRUE){
   varname = .check_character(cause,effect)
   E = .check_inputelementnum(E,2)
   tau = .check_inputelementnum(tau,2)
@@ -10,9 +10,9 @@
 
   x_xmap_y = NULL
   if (bidirectional){
-    x_xmap_y = RcppMultispatialCCM(cause,effect,libsizes,E[1],tau[1],k[1],boot,seed,threads,pl,progressbar)
+    x_xmap_y = RcppMultispatialCCM(cause,effect,libsizes,E[1],tau[1],k[1],boot,seed,threads,pl,.check_distmetric(dist.metric),dist.average,progressbar)
   }
-  y_xmap_x = RcppMultispatialCCM(effect,cause,libsizes,E[2],tau[2],k[2],boot,seed,threads,pl,progressbar)
+  y_xmap_x = RcppMultispatialCCM(effect,cause,libsizes,E[2],tau[2],k[2],boot,seed,threads,pl,.check_distmetric(dist.metric),dist.average,progressbar)
 
   return(.bind_xmapdf(varname,x_xmap_y,y_xmap_x,bidirectional))
 }
@@ -28,6 +28,8 @@
 #' @param k (optional) number of nearest neighbors used in prediction.
 #' @param boot (optional) number of bootstraps to perform.
 #' @param seed (optional) random seed.
+#' @param dist.metric (optional) distance metric (`L1`: Manhattan, `L2`: Euclidean).
+#' @param dist.average (optional) whether to average distance.
 #' @param threads (optional) number of threads to use.
 #' @param parallel.level (optional) level of parallelism, `low` or `high`.
 #' @param bidirectional (optional) whether to examine bidirectional causality.

--- a/R/pcm.R
+++ b/R/pcm.R
@@ -1,5 +1,5 @@
-.pcm_ts_method = \(data, cause, effect, conds, libsizes = NULL, E = 3, tau = 0, k = E+1, theta = 1, algorithm = "simplex", lib = NULL,
-                   pred = NULL, threads = length(pred), parallel.level = "low", bidirectional = TRUE, cumulate = FALSE, progressbar = TRUE){
+.pcm_ts_method = \(data, cause, effect, conds, libsizes = NULL, E = 3, tau = 0, k = E+1, theta = 1, algorithm = "simplex", lib = NULL, pred = NULL, dist.metric = "L2",
+                   dist.average = TRUE, threads = length(pred), parallel.level = "low", bidirectional = TRUE, cumulate = FALSE, progressbar = TRUE){
   varname = .check_character(c(cause, effect, conds))
   E = .check_inputelementnum(E,length(varname),length(conds))
   tau = .check_inputelementnum(tau,length(varname))
@@ -17,9 +17,9 @@
   simplex = ifelse(algorithm == "simplex", TRUE, FALSE)
   x_xmap_y = NULL
   if (bidirectional){
-    x_xmap_y = RcppPCM(cause,effect,condmat,libsizes,lib,pred,E[-2],tau[-2],k[-2],simplex,theta,threads,pl,cumulate,progressbar)
+    x_xmap_y = RcppPCM(cause,effect,condmat,libsizes,lib,pred,E[-2],tau[-2],k[-2],simplex,theta,threads,pl,cumulate,.check_distmetric(dist.metric),dist.average,progressbar)
   }
-  y_xmap_x = RcppPCM(effect,cause,condmat,libsizes,lib,pred,E[-1],tau[-1],k[-1],simplex,theta,threads,pl,cumulate,progressbar)
+  y_xmap_x = RcppPCM(effect,cause,condmat,libsizes,lib,pred,E[-1],tau[-1],k[-1],simplex,theta,threads,pl,cumulate,.check_distmetric(dist.metric),dist.average,progressbar)
 
   return(.bind_xmapdf2(varname,x_xmap_y,y_xmap_x,bidirectional))
 }

--- a/man/ccm.Rd
+++ b/man/ccm.Rd
@@ -17,6 +17,8 @@
   algorithm = "simplex",
   lib = NULL,
   pred = NULL,
+  dist.metric = "L2",
+  dist.average = TRUE,
   threads = length(pred),
   parallel.level = "low",
   bidirectional = TRUE,
@@ -45,6 +47,10 @@
 \item{lib}{(optional) libraries indices.}
 
 \item{pred}{(optional) predictions indices.}
+
+\item{dist.metric}{(optional) distance metric (\code{L1}: Manhattan, \code{L2}: Euclidean).}
+
+\item{dist.average}{(optional) whether to average distance.}
 
 \item{threads}{(optional) number of threads to use.}
 

--- a/man/multispatialccm.Rd
+++ b/man/multispatialccm.Rd
@@ -15,6 +15,8 @@
   k = E + 1,
   boot = 99,
   seed = 42,
+  dist.metric = "L2",
+  dist.average = TRUE,
   threads = length(libsizes),
   parallel.level = "low",
   bidirectional = TRUE,
@@ -39,6 +41,10 @@
 \item{boot}{(optional) number of bootstraps to perform.}
 
 \item{seed}{(optional) random seed.}
+
+\item{dist.metric}{(optional) distance metric (\code{L1}: Manhattan, \code{L2}: Euclidean).}
+
+\item{dist.average}{(optional) whether to average distance.}
 
 \item{threads}{(optional) number of threads to use.}
 

--- a/man/pcm.Rd
+++ b/man/pcm.Rd
@@ -18,6 +18,8 @@
   algorithm = "simplex",
   lib = NULL,
   pred = NULL,
+  dist.metric = "L2",
+  dist.average = TRUE,
   threads = length(pred),
   parallel.level = "low",
   bidirectional = TRUE,
@@ -49,6 +51,10 @@
 \item{lib}{(optional) libraries indices.}
 
 \item{pred}{(optional) predictions indices.}
+
+\item{dist.metric}{(optional) distance metric (\code{L1}: Manhattan, \code{L2}: Euclidean).}
+
+\item{dist.average}{(optional) whether to average distance.}
 
 \item{threads}{(optional) number of threads to use.}
 

--- a/src/CCM.cpp
+++ b/src/CCM.cpp
@@ -156,6 +156,8 @@ std::vector<std::pair<int, double>> CCMSingle(
  * - theta: Distance weighting parameter used for weighting neighbors in the S-mapping prediction.
  * - threads: Number of threads to use for parallel computation.
  * - parallel_level: Level of parallel computing: 0 for `lower`, 1 for `higher`.
+ *   dist_metric    - Distance metric selector (1: Manhattan, 2: Euclidean).
+ *   dist_average   - Whether to average distance by the number of valid vector components.
  * - progressbar: Boolean flag to indicate whether to display a progress bar during computation.
  *
  * Returns:
@@ -172,14 +174,16 @@ std::vector<std::vector<double>> CCM(
     const std::vector<int>& lib_sizes,
     const std::vector<int>& lib,
     const std::vector<int>& pred,
-    int E,
-    int tau,
-    int b,
-    bool simplex,
-    double theta,
-    int threads,
-    int parallel_level,
-    bool progressbar
+    int E = 3,
+    int tau = 1,
+    int b = 4,
+    bool simplex = true,
+    double theta = 1.0,
+    int threads = 8,
+    int parallel_level = 0,
+    int dist_metric = 2,
+    bool dist_average = true,
+    bool progressbar = false
 ) {
   // If b is not provided correctly, default it to E + 1
   if (b <= 0) {
@@ -229,7 +233,9 @@ std::vector<std::vector<double>> CCM(
           simplex,
           theta,
           threads_sizet,
-          parallel_level);
+          parallel_level,
+          dist_metric,
+          dist_average);
         bar++;
       }
     } else {
@@ -244,7 +250,9 @@ std::vector<std::vector<double>> CCM(
           simplex,
           theta,
           threads_sizet,
-          parallel_level);
+          parallel_level,
+          dist_metric,
+          dist_average);
       }
     }
   } else {
@@ -263,7 +271,9 @@ std::vector<std::vector<double>> CCM(
           simplex,
           theta,
           threads_sizet,
-          parallel_level);
+          parallel_level,
+          dist_metric,
+          dist_average);
         bar++;
       }, threads_sizet);
     } else {
@@ -279,7 +289,9 @@ std::vector<std::vector<double>> CCM(
           simplex,
           theta,
           threads_sizet,
-          parallel_level);
+          parallel_level,
+          dist_metric,
+          dist_average);
       }, threads_sizet);
     }
   }

--- a/src/CCM.cpp
+++ b/src/CCM.cpp
@@ -27,6 +27,8 @@
  *   - theta: Distance weighting parameter for local neighbors in the manifold (used in s-mapping).
  *   - threads: The number of threads to use for parallel processing.
  *   - parallel_level: Level of parallel computing: 0 for `lower`, 1 for `higher`.
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components.
  *
  * Returns:
  *   A vector of pairs, where each pair consists of:
@@ -43,7 +45,9 @@ std::vector<std::pair<int, double>> CCMSingle(
     bool simplex,
     double theta,
     size_t threads,
-    int parallel_level
+    int parallel_level,
+    int dist_metric,
+    bool dist_average
 ) {
   int max_lib_size = lib_indices.size();
 
@@ -54,9 +58,9 @@ std::vector<std::pair<int, double>> CCMSingle(
     // Run cross map and store results
     double rho = std::numeric_limits<double>::quiet_NaN();
     if (simplex) {
-      rho = SimplexProjection(x_vectors, y, lib_indices, pred_indices, b);
+      rho = SimplexProjection(x_vectors, y, lib_indices, pred_indices, b, dist_metric, dist_average);
     } else {
-      rho = SMap(x_vectors, y, lib_indices, pred_indices, b, theta);
+      rho = SMap(x_vectors, y, lib_indices, pred_indices, b, theta, dist_metric, dist_average);
     }
     x_xmap_y.emplace_back(lib_size, rho);
     return x_xmap_y;
@@ -91,9 +95,9 @@ std::vector<std::pair<int, double>> CCMSingle(
       // Run cross map and store results
       double rho = std::numeric_limits<double>::quiet_NaN();
       if (simplex) {
-        rho = SimplexProjection(x_vectors, y, valid_lib_indices[i], pred_indices, b);
+        rho = SimplexProjection(x_vectors, y, valid_lib_indices[i], pred_indices, b, dist_metric, dist_average);
       } else {
-        rho = SMap(x_vectors, y, valid_lib_indices[i], pred_indices, b, theta);
+        rho = SMap(x_vectors, y, valid_lib_indices[i], pred_indices, b, theta, dist_metric, dist_average);
       }
 
       std::pair<int, double> result(lib_size, rho); // Store the product of row and column library sizes
@@ -125,9 +129,9 @@ std::vector<std::pair<int, double>> CCMSingle(
       // Run cross map and store results
       double rho = std::numeric_limits<double>::quiet_NaN();
       if (simplex) {
-        rho = SimplexProjection(x_vectors, y, local_lib_indices, pred_indices, b);
+        rho = SimplexProjection(x_vectors, y, local_lib_indices, pred_indices, b, dist_metric, dist_average);
       } else {
-        rho = SMap(x_vectors, y, local_lib_indices, pred_indices, b, theta);
+        rho = SMap(x_vectors, y, local_lib_indices, pred_indices, b, theta, dist_metric, dist_average);
       }
       x_xmap_y.emplace_back(lib_size, rho);
     }

--- a/src/CCM.h
+++ b/src/CCM.h
@@ -28,6 +28,8 @@
  *   - theta: Distance weighting parameter for local neighbors in the manifold (used in s-mapping).
  *   - threads: The number of threads to use for parallel processing.
  *   - parallel_level: Level of parallel computing: 0 for `lower`, 1 for `higher`.
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components.
  *
  * Returns:
  *   A vector of pairs, where each pair consists of:
@@ -44,7 +46,9 @@ std::vector<std::pair<int, double>> CCMSingle(
     bool simplex,
     double theta,
     size_t threads,
-    int parallel_level
+    int parallel_level,
+    int dist_metric,
+    bool dist_average
 );
 
 /**
@@ -63,6 +67,8 @@ std::vector<std::pair<int, double>> CCMSingle(
  * - theta: Distance weighting parameter used for weighting neighbors in the S-mapping prediction.
  * - threads: Number of threads to use for parallel computation.
  * - parallel_level: Level of parallel computing: 0 for `lower`, 1 for `higher`.
+ *   dist_metric    - Distance metric selector (1: Manhattan, 2: Euclidean).
+ *   dist_average   - Whether to average distance by the number of valid vector components.
  * - progressbar: Boolean flag to indicate whether to display a progress bar during computation.
  *
  * Returns:
@@ -79,14 +85,16 @@ std::vector<std::vector<double>> CCM(
     const std::vector<int>& lib_sizes,
     const std::vector<int>& lib,
     const std::vector<int>& pred,
-    int E,
-    int tau,
-    int b,
-    bool simplex,
-    double theta,
-    int threads,
-    int parallel_level,
-    bool progressbar
+    int E = 3,
+    int tau = 1,
+    int b = 4,
+    bool simplex = true,
+    double theta = 1.0,
+    int threads = 8,
+    int parallel_level = 0,
+    int dist_metric = 2,
+    bool dist_average = true,
+    bool progressbar = false
 );
 
 #endif // CCM_H

--- a/src/EDMExp.cpp
+++ b/src/EDMExp.cpp
@@ -832,6 +832,8 @@ Rcpp::NumericMatrix RcppCCM(const Rcpp::NumericVector& x,
                             double theta = 0,
                             int threads = 8,
                             int parallel_level = 0,
+                            int dist_metric = 2,
+                            bool dist_average = true,
                             bool progressbar = false) {
   // Convert Rcpp::NumericVector to std::vector<double>
   std::vector<double> x_std = Rcpp::as<std::vector<double>>(x);
@@ -879,6 +881,8 @@ Rcpp::NumericMatrix RcppCCM(const Rcpp::NumericVector& x,
     theta,
     threads,
     parallel_level,
+    dist_metric,
+    dist_average,
     progressbar);
 
   // Convert std::vector<std::vector<double>> to Rcpp::NumericMatrix
@@ -915,6 +919,8 @@ Rcpp::NumericMatrix RcppPCM(const Rcpp::NumericVector& x,
                             int threads = 8,
                             int parallel_level = 0,
                             bool cumulate = false,
+                            int dist_metric = 2,
+                            bool dist_average = true,
                             bool progressbar = false) {
   // Convert Rcpp::NumericVector to std::vector<double>
   std::vector<double> x_std = Rcpp::as<std::vector<double>>(x);
@@ -984,6 +990,8 @@ Rcpp::NumericMatrix RcppPCM(const Rcpp::NumericVector& x,
     threads,
     parallel_level,
     cumulate,
+    dist_metric,
+    dist_average,
     progressbar);
 
   // Convert std::vector<std::vector<double>> to Rcpp::NumericMatrix
@@ -1117,6 +1125,8 @@ Rcpp::NumericMatrix RcppMultispatialCCM(const Rcpp::NumericMatrix& x,
                                         int seed = 42,
                                         int threads = 8,
                                         int parallel_level = 0,
+                                        int dist_metric = 2,
+                                        bool dist_average = true,
                                         bool progressbar = false) {
   // Convert Rcpp NumericMatrix to std::vector of std::vectors
   std::vector<std::vector<double>> x_std(x.ncol());
@@ -1145,6 +1155,8 @@ Rcpp::NumericMatrix RcppMultispatialCCM(const Rcpp::NumericMatrix& x,
     threads,
     std::abs(seed),
     parallel_level,
+    dist_metric,
+    dist_average,
     progressbar);
 
   // Convert std::vector<std::vector<double>> to Rcpp::NumericMatrix

--- a/src/MultispatialCCM.cpp
+++ b/src/MultispatialCCM.cpp
@@ -160,6 +160,8 @@ std::vector<double> SimplexPredictionBoot(
  *   threads        - Number of threads to use for parallel processing.
  *   seed           - Random seed for reproducibility.
  *   parallel_level - 0 for sequential execution; >0 enables parallelization with RcppThread.
+ *   dist_metric    - Distance metric selector (1: Manhattan, 2: Euclidean).
+ *   dist_average   - Whether to average distance by the number of valid vector components.
  *   progressbar    - Logical flag to enable/disable a progress bar during execution.
  *
  * Returns:
@@ -181,6 +183,8 @@ std::vector<std::vector<double>> MultispatialCCM(
     int threads,
     unsigned int seed = 42,
     int parallel_level = 0,
+    int dist_metric = 2,
+    bool dist_average = true,
     bool progressbar = true
 ) {
   // If b is not provided correctly, default it to E + 1
@@ -225,7 +229,9 @@ std::vector<std::vector<double>> MultispatialCCM(
           boot,
           threads_sizet,
           seed,
-          parallel_level);
+          parallel_level,
+          dist_metric,
+          dist_average);
         bar++;
       }
     } else {
@@ -240,7 +246,9 @@ std::vector<std::vector<double>> MultispatialCCM(
           boot,
           threads_sizet,
           seed,
-          parallel_level);
+          parallel_level,
+          dist_metric,
+          dist_average);
       }
     }
   } else {
@@ -259,7 +267,9 @@ std::vector<std::vector<double>> MultispatialCCM(
           boot,
           threads_sizet,
           seed,
-          parallel_level);
+          parallel_level,
+          dist_metric,
+          dist_average);
         bar++;
       }, threads_sizet);
     } else {
@@ -275,7 +285,9 @@ std::vector<std::vector<double>> MultispatialCCM(
           boot,
           threads_sizet,
           seed,
-          parallel_level);
+          parallel_level,
+          dist_metric,
+          dist_average);
       }, threads_sizet);
     }
   }

--- a/src/MultispatialCCM.cpp
+++ b/src/MultispatialCCM.cpp
@@ -26,6 +26,8 @@
  *   seed           - Random seed for reproducibility.
  *   boot           - Number of bootstrap replicates.
  *   parallel_level - If 0, run in parallel using RcppThread. Otherwise, run sequentially.
+ *   dist_metric    - Distance metric selector (1: Manhattan, 2: Euclidean).
+ *   dist_average   - Whether to average distance by the number of valid vector components.
  *
  * Returns:
  *   A vector of length 5:
@@ -45,7 +47,9 @@ std::vector<double> SimplexPredictionBoot(
     int boot,
     size_t threads,
     unsigned int seed = 42,
-    int parallel_level = 0
+    int parallel_level = 0,
+    int dist_metric = 2,
+    bool dist_average = true
 ) {
   int n_plot = source.size();
   std::vector<double> rho_list(boot, std::numeric_limits<double>::quiet_NaN());
@@ -92,7 +96,8 @@ std::vector<double> SimplexPredictionBoot(
     std::iota(all_indices.begin(), all_indices.end(), 0);
 
     auto pred = SimplexProjectionPrediction(library_vectors, library_targets,
-                                            all_indices, all_indices, num_neighbors);
+                                            all_indices, all_indices, num_neighbors,
+                                            dist_metric, dist_average);
 
     rho_list[b] = PearsonCor(library_targets, pred, true);
   };

--- a/src/MultispatialCCM.h
+++ b/src/MultispatialCCM.h
@@ -27,6 +27,8 @@
  *   seed           - Random seed for reproducibility.
  *   boot           - Number of bootstrap replicates.
  *   parallel_level - If 0, run in parallel using RcppThread. Otherwise, run sequentially.
+ *   dist_metric    - Distance metric selector (1: Manhattan, 2: Euclidean).
+ *   dist_average   - Whether to average distance by the number of valid vector components.
  *
  * Returns:
  *   A vector of length 5:
@@ -46,7 +48,9 @@ std::vector<double> SimplexPredictionBoot(
     int boot,
     size_t threads,
     unsigned int seed = 42,
-    int parallel_level = 0
+    int parallel_level = 0,
+    int dist_metric = 2,
+    bool dist_average = true
 );
 
 /*
@@ -72,6 +76,8 @@ std::vector<double> SimplexPredictionBoot(
  *   threads        - Number of threads to use for parallel processing.
  *   seed           - Random seed for reproducibility.
  *   parallel_level - 0 for sequential execution; >0 enables parallelization with RcppThread.
+ *   dist_metric    - Distance metric selector (1: Manhattan, 2: Euclidean).
+ *   dist_average   - Whether to average distance by the number of valid vector components.
  *   progressbar    - Logical flag to enable/disable a progress bar during execution.
  *
  * Returns:
@@ -93,6 +99,8 @@ std::vector<std::vector<double>> MultispatialCCM(
     int threads,
     unsigned int seed = 42,
     int parallel_level = 0,
+    int dist_metric = 2,
+    bool dist_average = true,
     bool progressbar = true
 );
 

--- a/src/PCM.cpp
+++ b/src/PCM.cpp
@@ -46,7 +46,7 @@ std::vector<double> PartialSimplex4TS(
     bool cumulate = false,
     int dist_metric = 2,
     bool dist_average = true
-){
+) {
   int n_controls = controls.size();
   std::vector<double> rho(2, std::numeric_limits<double>::quiet_NaN());
 
@@ -131,7 +131,7 @@ std::vector<double> PartialSMap4TS(
     bool cumulate = false,
     int dist_metric = 2,
     bool dist_average = true
-){
+) {
   int n_controls = controls.size();
   std::vector<double> rho(2, std::numeric_limits<double>::quiet_NaN());
 

--- a/src/PCM.cpp
+++ b/src/PCM.cpp
@@ -197,6 +197,8 @@ std::vector<double> PartialSMap4TS(
  *   - threads: The number of threads to use for parallel processing.
  *   - parallel_level: Level of parallel computing: 0 for `lower`, 1 for `higher`.
  *   - cumulate: Whether to accumulate partial correlations.
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components.
  *
  * Returns:
  *   A vector of PartialCorRes objects, where each contains:
@@ -218,7 +220,9 @@ std::vector<PartialCorRes> PCMSingle(
     double theta,                                       // Distance weighting parameter for the local neighbours in the manifold
     size_t threads,                                     // Number of threads to use for parallel processing
     int parallel_level,                                 // Level of parallel computing: 0 for `lower`, 1 for `higher`
-    bool cumulate                                       // Whether to cumulate the partial correlations
+    bool cumulate,                                      // Whether to cumulate the partial correlations
+    int dist_metric,                                    // Distance metric selector (1: Manhattan, 2: Euclidean)
+    bool dist_average                                   // Whether to average distance by the number of valid vector components
 ) {
   int max_lib_size = lib_indices.size();
 
@@ -228,9 +232,9 @@ std::vector<PartialCorRes> PCMSingle(
     // Run partial cross map and store results
     std::vector<double> rho;
     if (simplex) {
-      rho = PartialSimplex4TS(x_vectors, y, controls, lib_indices, pred_indices, conEs, taus, b, cumulate);
+      rho = PartialSimplex4TS(x_vectors, y, controls, lib_indices, pred_indices, conEs, taus, b, cumulate, dist_metric, dist_average);
     } else {
-      rho = PartialSMap4TS(x_vectors, y, controls, lib_indices, pred_indices, conEs, taus, b, theta, cumulate);
+      rho = PartialSMap4TS(x_vectors, y, controls, lib_indices, pred_indices, conEs, taus, b, theta, cumulate, dist_metric, dist_average);
     }
     x_xmap_y.emplace_back(lib_size, rho[0], rho[1]);
     return x_xmap_y;
@@ -265,9 +269,9 @@ std::vector<PartialCorRes> PCMSingle(
       // Run partial cross map and store results
       std::vector<double> rho;
       if (simplex) {
-        rho = PartialSimplex4TS(x_vectors, y, controls, valid_lib_indices[i], pred_indices, conEs, taus, b, cumulate);
+        rho = PartialSimplex4TS(x_vectors, y, controls, valid_lib_indices[i], pred_indices, conEs, taus, b, cumulate, dist_metric, dist_average);
       } else {
-        rho = PartialSMap4TS(x_vectors, y, controls, valid_lib_indices[i], pred_indices, conEs, taus, b, theta, cumulate);
+        rho = PartialSMap4TS(x_vectors, y, controls, valid_lib_indices[i], pred_indices, conEs, taus, b, theta, cumulate, dist_metric, dist_average);
       }
       // Directly initialize a PartialCorRes struct with the three values
       PartialCorRes result(lib_size, rho[0], rho[1]);
@@ -299,9 +303,9 @@ std::vector<PartialCorRes> PCMSingle(
       // Run partial cross map and store results
       std::vector<double> rho;
       if (simplex) {
-        rho = PartialSimplex4TS(x_vectors, y, controls, local_lib_indices, pred_indices, conEs, taus, b, cumulate);
+        rho = PartialSimplex4TS(x_vectors, y, controls, local_lib_indices, pred_indices, conEs, taus, b, cumulate, dist_metric, dist_average);
       } else {
-        rho = PartialSMap4TS(x_vectors, y, controls, local_lib_indices, pred_indices, conEs, taus, b, theta, cumulate);
+        rho = PartialSMap4TS(x_vectors, y, controls, local_lib_indices, pred_indices, conEs, taus, b, theta, cumulate, dist_metric, dist_average);
       }
       x_xmap_y.emplace_back(lib_size, rho[0], rho[1]);
     }
@@ -328,6 +332,8 @@ std::vector<PartialCorRes> PCMSingle(
  * - threads: Number of threads to use for parallel computation.
  * - cumulate: Boolean flag indicating whether to cumulate partial correlations.
  * - parallel_level: Level of parallel computing: 0 for `lower`, 1 for `higher`.
+ * - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean).
+ * - dist_average: Whether to average distance by the number of valid vector components.
  * - progressbar: Boolean flag indicating whether to display a progress bar during computation.
  *
  * Returns:
@@ -357,6 +363,8 @@ std::vector<std::vector<double>> PCM(
     int threads,                                        // Number of threads used from the global pool
     int parallel_level,                                 // Level of parallel computing: 0 for `lower`, 1 for `higher`
     bool cumulate,                                      // Whether to cumulate the partial correlations
+    int dist_metric,                                    // Distance metric selector (1: Manhattan, 2: Euclidean)
+    bool dist_average,                                  // Whether to average distance by the number of valid vector components
     bool progressbar                                    // Whether to print the progress bar
 ) {
   // If b is not provided correctly, default it to E + 2
@@ -427,7 +435,9 @@ std::vector<std::vector<double>> PCM(
           theta,
           threads_sizet,
           parallel_level,
-          cumulate
+          cumulate,
+          dist_metric,
+          dist_average
         );
         bar++;
       }
@@ -447,7 +457,9 @@ std::vector<std::vector<double>> PCM(
           theta,
           threads_sizet,
           parallel_level,
-          cumulate
+          cumulate,
+          dist_metric,
+          dist_average
         );
       }
     }
@@ -471,7 +483,9 @@ std::vector<std::vector<double>> PCM(
           theta,
           threads_sizet,
           parallel_level,
-          cumulate
+          cumulate,
+          dist_metric,
+          dist_average
         );
         bar++;
       }, threads_sizet);
@@ -492,7 +506,9 @@ std::vector<std::vector<double>> PCM(
           theta,
           threads_sizet,
           parallel_level,
-          cumulate
+          cumulate,
+          dist_metric,
+          dist_average
         );
       }, threads_sizet);
     }

--- a/src/PCM.cpp
+++ b/src/PCM.cpp
@@ -27,6 +27,8 @@
  * @param taus: Vector specifying the time lag step for constructing lagged state-space vectors with control variables.
  * @param num_neighbors: Vector specifying the numbers of neighbors to use for simplex projection.
  * @param cumulate: Flag indicating whether to cumulatively incorporate control variables.
+ * @param dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean).
+ * @param dist_average: Whether to average distance by the number of valid vector components.
  *
  * @return A std::vector<double> containing:
  *         - rho[0]: Pearson correlation between the target and its simplex projection.
@@ -41,7 +43,9 @@ std::vector<double> PartialSimplex4TS(
     const std::vector<int>& conEs,
     const std::vector<int>& taus,
     const std::vector<int>& num_neighbors,
-    bool cumulate
+    bool cumulate = false,
+    int dist_metric = 2,
+    bool dist_average = true
 ){
   int n_controls = controls.size();
   std::vector<double> rho(2, std::numeric_limits<double>::quiet_NaN());
@@ -53,15 +57,15 @@ std::vector<double> PartialSimplex4TS(
 
     for (int i = 0; i < n_controls; ++i) {
       if (i == 0){
-        temp_pred = SimplexProjectionPrediction(vectors, controls[i], lib_indices, pred_indices, num_neighbors[0]);
+        temp_pred = SimplexProjectionPrediction(vectors, controls[i], lib_indices, pred_indices, num_neighbors[0], dist_metric, dist_average);
       } else {
-        temp_pred = SimplexProjectionPrediction(temp_embedding, controls[i], lib_indices, pred_indices, num_neighbors[i]);
+        temp_pred = SimplexProjectionPrediction(temp_embedding, controls[i], lib_indices, pred_indices, num_neighbors[i], dist_metric, dist_average);
       }
       temp_embedding = Embed(temp_pred,conEs[i],taus[i]);
     }
 
-    std::vector<double> con_pred = SimplexProjectionPrediction(temp_embedding, target, lib_indices, pred_indices, num_neighbors[n_controls]);
-    std::vector<double> target_pred = SimplexProjectionPrediction(vectors, target, lib_indices, pred_indices, num_neighbors[0]);
+    std::vector<double> con_pred = SimplexProjectionPrediction(temp_embedding, target, lib_indices, pred_indices, num_neighbors[n_controls], dist_metric, dist_average);
+    std::vector<double> target_pred = SimplexProjectionPrediction(vectors, target, lib_indices, pred_indices, num_neighbors[0], dist_metric, dist_average);
 
     if (checkOneDimVectorNotNanNum(target_pred) >= 3){
       rho[0] = PearsonCor(target,target_pred,true);
@@ -74,12 +78,12 @@ std::vector<double> PartialSimplex4TS(
     std::vector<std::vector<double>> temp_embedding;
 
     for (int i = 0; i < n_controls; ++i) {
-      temp_pred = SimplexProjectionPrediction(vectors, controls[i], lib_indices, pred_indices, num_neighbors[0]);
+      temp_pred = SimplexProjectionPrediction(vectors, controls[i], lib_indices, pred_indices, num_neighbors[0], dist_metric, dist_average);
       temp_embedding = Embed(temp_pred,conEs[i],taus[i]);
-      temp_pred = SimplexProjectionPrediction(temp_embedding, target, lib_indices, pred_indices, num_neighbors[i+1]);
+      temp_pred = SimplexProjectionPrediction(temp_embedding, target, lib_indices, pred_indices, num_neighbors[i+1], dist_metric, dist_average);
       con_pred[i] = temp_pred;
     }
-    std::vector<double> target_pred = SimplexProjectionPrediction(vectors, target, lib_indices, pred_indices, num_neighbors[0]);
+    std::vector<double> target_pred = SimplexProjectionPrediction(vectors, target, lib_indices, pred_indices, num_neighbors[0], dist_metric, dist_average);
 
     if (checkOneDimVectorNotNanNum(target_pred) >= 3){
       rho[0] = PearsonCor(target,target_pred,true);
@@ -108,6 +112,8 @@ std::vector<double> PartialSimplex4TS(
  * @param num_neighbors: Vector specifying the numbers of neighbors to use for S-Map prediction.
  * @param theta: Weighting parameter for distances in S-Map.
  * @param cumulate: Boolean flag to determine whether to cumulate the partial correlations.
+ * @param dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean).
+ * @param dist_average: Whether to average distance by the number of valid vector components.
  * @return A vector of size 2 containing:
  *         - rho[0]: Pearson correlation between the target and its predicted values.
  *         - rho[1]: Partial correlation between the target and its predicted values, adjusting for control variables.
@@ -121,8 +127,10 @@ std::vector<double> PartialSMap4TS(
     const std::vector<int>& conEs,
     const std::vector<int>& taus,
     const std::vector<int>& num_neighbors,
-    double theta,
-    bool cumulate
+    double theta = 1.0,
+    bool cumulate = false,
+    int dist_metric = 2,
+    bool dist_average = true
 ){
   int n_controls = controls.size();
   std::vector<double> rho(2, std::numeric_limits<double>::quiet_NaN());
@@ -134,15 +142,15 @@ std::vector<double> PartialSMap4TS(
 
     for (int i = 0; i < n_controls; ++i) {
       if (i == 0){
-        temp_pred = SMapPrediction(vectors, controls[i], lib_indices, pred_indices, num_neighbors[0], theta);
+        temp_pred = SMapPrediction(vectors, controls[i], lib_indices, pred_indices, num_neighbors[0], theta, dist_metric, dist_average);
       } else {
-        temp_pred = SMapPrediction(temp_embedding, controls[i], lib_indices, pred_indices, num_neighbors[i], theta);
+        temp_pred = SMapPrediction(temp_embedding, controls[i], lib_indices, pred_indices, num_neighbors[i], theta, dist_metric, dist_average);
       }
       temp_embedding = Embed(temp_pred,conEs[i],taus[i]);
     }
 
-    std::vector<double> con_pred = SMapPrediction(temp_embedding, target, lib_indices, pred_indices, num_neighbors[n_controls], theta);
-    std::vector<double> target_pred = SMapPrediction(vectors, target, lib_indices, pred_indices, num_neighbors[0], theta);
+    std::vector<double> con_pred = SMapPrediction(temp_embedding, target, lib_indices, pred_indices, num_neighbors[n_controls], theta, dist_metric, dist_average);
+    std::vector<double> target_pred = SMapPrediction(vectors, target, lib_indices, pred_indices, num_neighbors[0], theta, dist_metric, dist_average);
 
     if (checkOneDimVectorNotNanNum(target_pred) >= 3){
       rho[0] = PearsonCor(target,target_pred,true);
@@ -155,12 +163,12 @@ std::vector<double> PartialSMap4TS(
     std::vector<std::vector<double>> temp_embedding;
 
     for (int i = 0; i < n_controls; ++i) {
-      temp_pred = SMapPrediction(vectors, controls[i], lib_indices, pred_indices, num_neighbors[0], theta);
+      temp_pred = SMapPrediction(vectors, controls[i], lib_indices, pred_indices, num_neighbors[0], theta, dist_metric, dist_average);
       temp_embedding = Embed(temp_pred,conEs[i],taus[i]);
-      temp_pred = SMapPrediction(temp_embedding, target, lib_indices, pred_indices, num_neighbors[i+1], theta);
+      temp_pred = SMapPrediction(temp_embedding, target, lib_indices, pred_indices, num_neighbors[i+1], theta, dist_metric, dist_average);
       con_pred[i] = temp_pred;
     }
-    std::vector<double> target_pred = SMapPrediction(vectors, target, lib_indices, pred_indices, num_neighbors[0], theta);
+    std::vector<double> target_pred = SMapPrediction(vectors, target, lib_indices, pred_indices, num_neighbors[0], theta, dist_metric, dist_average);
 
     if (checkOneDimVectorNotNanNum(target_pred) >= 3){
       rho[0] = PearsonCor(target,target_pred,true);

--- a/src/PCM.h
+++ b/src/PCM.h
@@ -28,6 +28,8 @@
  * @param taus: Vector specifying the time lag step for constructing lagged state-space vectors with control variables.
  * @param num_neighbors: Vector specifying the numbers of neighbors to use for simplex projection.
  * @param cumulate: Flag indicating whether to cumulatively incorporate control variables.
+ * @param dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean).
+ * @param dist_average: Whether to average distance by the number of valid vector components.
  *
  * @return A std::vector<double> containing:
  *         - rho[0]: Pearson correlation between the target and its simplex projection.
@@ -42,7 +44,9 @@ std::vector<double> PartialSimplex4TS(
     const std::vector<int>& conEs,
     const std::vector<int>& taus,
     const std::vector<int>& num_neighbors,
-    bool cumulate
+    bool cumulate = false,
+    int dist_metric = 2,
+    bool dist_average = true
 );
 
 /**
@@ -63,6 +67,8 @@ std::vector<double> PartialSimplex4TS(
  * @param num_neighbors: Vector specifying the numbers of neighbors to use for S-Map prediction.
  * @param theta: Weighting parameter for distances in S-Map.
  * @param cumulate: Boolean flag to determine whether to cumulate the partial correlations.
+ * @param dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean).
+ * @param dist_average: Whether to average distance by the number of valid vector components.
  * @return A vector of size 2 containing:
  *         - rho[0]: Pearson correlation between the target and its predicted values.
  *         - rho[1]: Partial correlation between the target and its predicted values, adjusting for control variables.
@@ -76,8 +82,10 @@ std::vector<double> PartialSMap4TS(
     const std::vector<int>& conEs,
     const std::vector<int>& taus,
     const std::vector<int>& num_neighbors,
-    double theta,
-    bool cumulate
+    double theta = 1.0,
+    bool cumulate = false,
+    int dist_metric = 2,
+    bool dist_average = true
 );
 
 /*
@@ -98,6 +106,8 @@ std::vector<double> PartialSMap4TS(
  *   - threads: The number of threads to use for parallel processing.
  *   - parallel_level: Level of parallel computing: 0 for `lower`, 1 for `higher`.
  *   - cumulate: Whether to accumulate partial correlations.
+ *   - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean).
+ *   - dist_average: Whether to average distance by the number of valid vector components.
  *
  * Returns:
  *   A vector of PartialCorRes objects, where each contains:
@@ -119,7 +129,9 @@ std::vector<PartialCorRes> PCMSingle(
     double theta,                                       // Distance weighting parameter for the local neighbours in the manifold
     size_t threads,                                     // Number of threads to use for parallel processing
     int parallel_level,                                 // Level of parallel computing: 0 for `lower`, 1 for `higher`
-    bool cumulate                                       // Whether to cumulate the partial correlations
+    bool cumulate,                                      // Whether to cumulate the partial correlations
+    int dist_metric,                                    // Distance metric selector (1: Manhattan, 2: Euclidean)
+    bool dist_average                                   // Whether to average distance by the number of valid vector components
 );
 
 /**
@@ -140,6 +152,8 @@ std::vector<PartialCorRes> PCMSingle(
  * - threads: Number of threads to use for parallel computation.
  * - cumulate: Boolean flag indicating whether to cumulate partial correlations.
  * - parallel_level: Level of parallel computing: 0 for `lower`, 1 for `higher`.
+ * - dist_metric: Distance metric selector (1: Manhattan, 2: Euclidean).
+ * - dist_average: Whether to average distance by the number of valid vector components.
  * - progressbar: Boolean flag indicating whether to display a progress bar during computation.
  *
  * Returns:
@@ -169,6 +183,8 @@ std::vector<std::vector<double>> PCM(
     int threads,                                        // Number of threads used from the global pool
     int parallel_level,                                 // Level of parallel computing: 0 for `lower`, 1 for `higher`
     bool cumulate,                                      // Whether to cumulate the partial correlations
+    int dist_metric,                                    // Distance metric selector (1: Manhattan, 2: Euclidean)
+    bool dist_average,                                  // Whether to average distance by the number of valid vector components
     bool progressbar                                    // Whether to print the progress bar
 );
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -222,8 +222,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppCCM
-Rcpp::NumericMatrix RcppCCM(const Rcpp::NumericVector& x, const Rcpp::NumericVector& y, const Rcpp::IntegerVector& libsizes, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, int E, int tau, int b, bool simplex, double theta, int threads, int parallel_level, bool progressbar);
-RcppExport SEXP _tEDM_RcppCCM(SEXP xSEXP, SEXP ySEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP simplexSEXP, SEXP thetaSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP progressbarSEXP) {
+Rcpp::NumericMatrix RcppCCM(const Rcpp::NumericVector& x, const Rcpp::NumericVector& y, const Rcpp::IntegerVector& libsizes, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, int E, int tau, int b, bool simplex, double theta, int threads, int parallel_level, int dist_metric, bool dist_average, bool progressbar);
+RcppExport SEXP _tEDM_RcppCCM(SEXP xSEXP, SEXP ySEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP simplexSEXP, SEXP thetaSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP dist_metricSEXP, SEXP dist_averageSEXP, SEXP progressbarSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type x(xSEXP);
@@ -238,14 +238,16 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< double >::type theta(thetaSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
     Rcpp::traits::input_parameter< int >::type parallel_level(parallel_levelSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
+    Rcpp::traits::input_parameter< bool >::type dist_average(dist_averageSEXP);
     Rcpp::traits::input_parameter< bool >::type progressbar(progressbarSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppCCM(x, y, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, progressbar));
+    rcpp_result_gen = Rcpp::wrap(RcppCCM(x, y, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, dist_metric, dist_average, progressbar));
     return rcpp_result_gen;
 END_RCPP
 }
 // RcppPCM
-Rcpp::NumericMatrix RcppPCM(const Rcpp::NumericVector& x, const Rcpp::NumericVector& y, const Rcpp::NumericMatrix& z, const Rcpp::IntegerVector& libsizes, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& tau, const Rcpp::IntegerVector& b, bool simplex, double theta, int threads, int parallel_level, bool cumulate, bool progressbar);
-RcppExport SEXP _tEDM_RcppPCM(SEXP xSEXP, SEXP ySEXP, SEXP zSEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP simplexSEXP, SEXP thetaSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP cumulateSEXP, SEXP progressbarSEXP) {
+Rcpp::NumericMatrix RcppPCM(const Rcpp::NumericVector& x, const Rcpp::NumericVector& y, const Rcpp::NumericMatrix& z, const Rcpp::IntegerVector& libsizes, const Rcpp::IntegerVector& lib, const Rcpp::IntegerVector& pred, const Rcpp::IntegerVector& E, const Rcpp::IntegerVector& tau, const Rcpp::IntegerVector& b, bool simplex, double theta, int threads, int parallel_level, bool cumulate, int dist_metric, bool dist_average, bool progressbar);
+RcppExport SEXP _tEDM_RcppPCM(SEXP xSEXP, SEXP ySEXP, SEXP zSEXP, SEXP libsizesSEXP, SEXP libSEXP, SEXP predSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP simplexSEXP, SEXP thetaSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP cumulateSEXP, SEXP dist_metricSEXP, SEXP dist_averageSEXP, SEXP progressbarSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type x(xSEXP);
@@ -262,8 +264,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
     Rcpp::traits::input_parameter< int >::type parallel_level(parallel_levelSEXP);
     Rcpp::traits::input_parameter< bool >::type cumulate(cumulateSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
+    Rcpp::traits::input_parameter< bool >::type dist_average(dist_averageSEXP);
     Rcpp::traits::input_parameter< bool >::type progressbar(progressbarSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppPCM(x, y, z, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, cumulate, progressbar));
+    rcpp_result_gen = Rcpp::wrap(RcppPCM(x, y, z, libsizes, lib, pred, E, tau, b, simplex, theta, threads, parallel_level, cumulate, dist_metric, dist_average, progressbar));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -290,8 +294,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // RcppMultispatialCCM
-Rcpp::NumericMatrix RcppMultispatialCCM(const Rcpp::NumericMatrix& x, const Rcpp::NumericMatrix& y, const Rcpp::IntegerVector& libsizes, int E, int tau, int b, int boot, int seed, int threads, int parallel_level, bool progressbar);
-RcppExport SEXP _tEDM_RcppMultispatialCCM(SEXP xSEXP, SEXP ySEXP, SEXP libsizesSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP bootSEXP, SEXP seedSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP progressbarSEXP) {
+Rcpp::NumericMatrix RcppMultispatialCCM(const Rcpp::NumericMatrix& x, const Rcpp::NumericMatrix& y, const Rcpp::IntegerVector& libsizes, int E, int tau, int b, int boot, int seed, int threads, int parallel_level, int dist_metric, bool dist_average, bool progressbar);
+RcppExport SEXP _tEDM_RcppMultispatialCCM(SEXP xSEXP, SEXP ySEXP, SEXP libsizesSEXP, SEXP ESEXP, SEXP tauSEXP, SEXP bSEXP, SEXP bootSEXP, SEXP seedSEXP, SEXP threadsSEXP, SEXP parallel_levelSEXP, SEXP dist_metricSEXP, SEXP dist_averageSEXP, SEXP progressbarSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type x(xSEXP);
@@ -304,8 +308,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
     Rcpp::traits::input_parameter< int >::type threads(threadsSEXP);
     Rcpp::traits::input_parameter< int >::type parallel_level(parallel_levelSEXP);
+    Rcpp::traits::input_parameter< int >::type dist_metric(dist_metricSEXP);
+    Rcpp::traits::input_parameter< bool >::type dist_average(dist_averageSEXP);
     Rcpp::traits::input_parameter< bool >::type progressbar(progressbarSEXP);
-    rcpp_result_gen = Rcpp::wrap(RcppMultispatialCCM(x, y, libsizes, E, tau, b, boot, seed, threads, parallel_level, progressbar));
+    rcpp_result_gen = Rcpp::wrap(RcppMultispatialCCM(x, y, libsizes, E, tau, b, boot, seed, threads, parallel_level, dist_metric, dist_average, progressbar));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -842,10 +848,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tEDM_RcppSMap4TS", (DL_FUNC) &_tEDM_RcppSMap4TS, 11},
     {"_tEDM_RcppMultiSimplex4TS", (DL_FUNC) &_tEDM_RcppMultiSimplex4TS, 10},
     {"_tEDM_RcppIC4TS", (DL_FUNC) &_tEDM_RcppIC4TS, 11},
-    {"_tEDM_RcppCCM", (DL_FUNC) &_tEDM_RcppCCM, 13},
-    {"_tEDM_RcppPCM", (DL_FUNC) &_tEDM_RcppPCM, 15},
+    {"_tEDM_RcppCCM", (DL_FUNC) &_tEDM_RcppCCM, 15},
+    {"_tEDM_RcppPCM", (DL_FUNC) &_tEDM_RcppPCM, 17},
     {"_tEDM_RcppCMC", (DL_FUNC) &_tEDM_RcppCMC, 13},
-    {"_tEDM_RcppMultispatialCCM", (DL_FUNC) &_tEDM_RcppMultispatialCCM, 11},
+    {"_tEDM_RcppMultispatialCCM", (DL_FUNC) &_tEDM_RcppMultispatialCCM, 13},
     {"_tEDM_DetectMaxNumThreads", (DL_FUNC) &_tEDM_DetectMaxNumThreads, 0},
     {"_tEDM_OptEmbedDim", (DL_FUNC) &_tEDM_OptEmbedDim, 1},
     {"_tEDM_OptThetaParm", (DL_FUNC) &_tEDM_OptThetaParm, 1},


### PR DESCRIPTION
Introduce configurable distance metrics in `ccm`, `pcm` and `multispatialccm` generics via the `dist.matric` and `dist.average` parameters.